### PR TITLE
Fix API URLs generated by Django REST when running behind a proxy

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -28,6 +28,7 @@ http {
         location / {
             proxy_pass http://peering-manager:8001;
             proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';


### PR DESCRIPTION
Django REST Framework seems to ignore X-Forwarded-Host header so a forced Host header has been added to nginx.conf. This fixed the behavior where API URLs were always generated with the host http://peering-manager:8001/ when running with Docker. (E.g. on /api/ URL.)