### PR TITLE
Add examples for peering-manager specific loggers

### DIFF
--- a/configuration/logging.py
+++ b/configuration/logging.py
@@ -38,6 +38,14 @@
 #        }
 #    },
 #    'loggers': {
+#        'peering.manager.peeringdb': {
+#            'handlers': ['console'],
+#            'level': LOGLEVEL
+#        },
+#        'peering.manager.napalm': {
+#            'handlers': ['console'],
+#            'level': 'DEBUG'
+#        },
 #        'django': {
 #            'handlers': ['console'],
 #            'propagate': True,


### PR DESCRIPTION
To help users figure out how to see debug messages