### PR TITLE
fix broken import at startup_scripts/020_tags.py

### DIFF
--- a/startup_scripts/020_tags.py
+++ b/startup_scripts/020_tags.py
@@ -1,6 +1,6 @@
 import sys
 
-from extras.models import Tag
+import extras.models
 from startup_script_utils import load_yaml
 from utils.enums import Colour
 
@@ -16,7 +16,7 @@ for params in tags:
             if color in color_tpl:
                 params["color"] = color_tpl[0]
 
-    tag, created = Tag.objects.get_or_create(**params)
+    tag, created = tags.Tag.objects.get_or_create(**params)
 
     if created:
         print(f"🎨 Created tag '{tag.name}'")


### PR DESCRIPTION
After introduction of extras/models/tags.py with the https://github.com/peering-manager/peering-manager/commit/3f8b9662b5f0b49d439ec0e23fb1485ae461d904 commit, docker-compose breaks with the following error:

```
peering-manager_1  |   File "/opt/peering-manager/startup_scripts/020_tags.py", line 3, in <module>
peering-manager_1  |     from extras.models import Tag
peering-manager_1  | ImportError: cannot import name 'Tag' from 'extras.models' (/opt/peering-manager/extras/models/__init__.py)
```
This PR edits startup_scripts/020_tags.py to fix this error.