### PR TITLE
Closes #42: bump base image to alpine:3.22

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -216,7 +216,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "${DOCKER_FROM}" ]; then
-  DOCKER_FROM="docker.io/alpine:3.20"
+  DOCKER_FROM="docker.io/alpine:3.22"
 fi
 
 ###


### PR DESCRIPTION
Bump the base image from alpine:3.20 to alpine:3.22 in order to get postgresql17-client instead of postgresql16-client to avoid a version mismatch in the included docker compose setup.