### PR TITLE
add COMMAND_DELAY to run-command.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
   peeringdb-sync:
     <<: *peering-manager
     environment:
+      COMMAND_DELAY: 120
       COMMAND_INTERVAL: 86400
     depends_on:
       peering-manager:

--- a/docker/run-command.sh
+++ b/docker/run-command.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+DELAY_SECONDS=${COMMAND_DELAY:=0}
 SLEEP_SECONDS=${COMMAND_INTERVAL:=86400}
 
+echo "Initial delay set to ${DELAY_SECONDS} seconds"
 echo "Interval set to ${SLEEP_SECONDS} seconds"
+sleep "${DELAY_SECONDS}s"
 while true; do
   date
   /opt/peering-manager/venv/bin/python /opt/peering-manager/manage.py ${@}


### PR DESCRIPTION
This adds COMMAND_DELAY to the run-command.sh so we can stagger the running of certain tasks for example in our installation we run:
/opt/peering-manager/run-command.sh peeringdb_sync
/opt/peering-manager/run-command.sh housekeeping
/opt/peering-manager/run-command.sh get_irr_data

These all run at the same time on reboot, by adding a delay we can stagger each task so that shared resources are not exhausted 